### PR TITLE
Take dishes and venues from 1 column --> 3 columns

### DIFF
--- a/app/controllers/dishes_controller.rb
+++ b/app/controllers/dishes_controller.rb
@@ -1,6 +1,7 @@
 class DishesController < ApplicationController
   def index
     @q = Dish.ransack(params[:q])
+    @q.sorts = 'name asc' if @q.sorts.empty?
     @dishes = @q.result(:distinct => true).includes(:cuisine, :bookmarks, :fans, :specialists).page(params[:page]).per(10)
     @bookmark = Bookmark.new
     @cuisines = Cuisine.all

--- a/app/views/dishes/index.html.erb
+++ b/app/views/dishes/index.html.erb
@@ -1,11 +1,6 @@
-<div class="page-header">
-  <h1>
-    <a href="/venues/new" class="btn btn-lg btn-success">Add a new venue</a>
-  </h1>
-</div>
-<div class="row mb-1">
-  
+<div class="row mt-2 mb-1">
   <div class="col-md-3">
+
     <%= search_form_for @q, :class => "collapse", :id => "dishes_filters" do |f| %>
       
       <p class="lead">Narrow results:</p>
@@ -38,11 +33,9 @@
     </a>
 
   </div>
-
-</div>
-
-<div class="row">
-  <div class="col-md-12">
+ 
+  <div class="col-md-6">
+    <div class="panel panel-default">
     <table class="table table-striped table-hover">
       <tr>
         <th>The very best...</th>
@@ -73,27 +66,30 @@
               <input type="hidden" name="user_id" value="<%= current_user.id %>">
         
               <!-- Label and input for venue_id -->
-              <div class = "form-group">
+              <div class="form-group">
                 <label for="venue_id" class="control-label sr-only">
                     Venue
                 </label>
+                
+              <div style="display:inline-block">
                 <%= select_tag(:venue_id, options_from_collection_for_select(Venue.all, :id, :name, @bookmark.venue_id), prompt:"Choose a venue...", :class => "form-control input-sm") %>
               </div>
               
               <button class="btn btn-primary btn-sm">
                 <i class="fa fa-heart"></i>
               </button>
-
+              </div>
       
             </form>
           <% end %>
         </td>
+        
         <td class="text-right">
-          <span class="label">
+          <span class="label label-primary">
             <% if dish.cuisine.present? %>
-              <a href="/cuisines/<%= dish.cuisine.id %>">
+              <!-- the target does not have this link <a href="/cuisines/<%= dish.cuisine.id %>"> -->
                 <%= dish.cuisine.name %>
-              </a>
+              <!-- the target does not have this link </a> -->
             <% end %>
           </span>
         </td>
@@ -102,6 +98,18 @@
       </tr>
       <% end %>
     </table>
+    <div class="text-center">
     <%= paginate @dishes, theme: 'twitter-bootstrap-4' %>
+    </div>
+    
   </div>
-</div>
+    </div>
+  
+  <div class="col-md-3">
+    <a href="/venues/new" class="btn btn-block btn-success">
+      Add a new venue
+    </a>
+  </div>
+  
+  
+  </div> <!-- This div closes the row. -->

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,7 +5,9 @@
   <title>VeryBest</title>
 
 
-  <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootswatch/3.3.7/journal/bootstrap.min.css">
+  
+  
   <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css">
 
   <style>

--- a/app/views/venues/index.html.erb
+++ b/app/views/venues/index.html.erb
@@ -1,52 +1,46 @@
-<div class="page-header">
-  <h1>
-    Venues
-    <a href="/venues/new" class="btn btn-lg btn-success">New Venue</a>
-  </h1>
-</div><div class="row mb-1">
-  <div class="col-md-12">
+<div class="row mt-2 mb-1">
+  <div class="col-md-3">
+
     <%= search_form_for @q, :class => "collapse", :id => "venues_filters" do |f| %>
       <p class="lead">Narrow results:</p>
 
-        <div class="form-group">
-    <%= f.label :name_cont, "Name contains" %>
-    <%= f.text_field :name_cont, :class => "form-control", :placeholder => "Name contains" %>
-  </div>
+    <div class="form-group">
+      <%= f.label :name_cont, "Name contains" %>
+      <%= f.text_field :name_cont, :class => "form-control", :placeholder => "Name contains" %>
+    </div>
 
-
-<div class="form-group">
+    <div class="form-group">
       <%= f.label :neighborhood_name_cont, "Neighborhood name contains" %>
       <%= f.text_field :neighborhood_name_cont, :class => "form-control", :placeholder => "Neighborhood name contains" %>
     </div>
 
 
-
-<div class="form-group">
+    <div class="form-group">
       <%= f.label :specialties_name_cont, "Bookmarked dish name contains" %>
       <%= f.text_field :specialties_name_cont, :class => "form-control", :placeholder => "Bookmarked dish name contains" %>
     </div>
 
-      <%= f.submit :class => "btn btn-primary btn-block mb-1" %>
+    <%= f.submit :class => "btn btn-primary btn-block mb-1" %>
 
-      <a href="/venues" class="btn btn-default btn-block mb-1">Clear filters</a>
+    <a href="/venues" class="btn btn-default btn-block mb-1">Clear filters</a>
     <% end %>
     <a class="btn btn-default btn-block mb-1" data-toggle="collapse" href="#venues_filters">
       Show Filters
     </a>
   </div>
-</div>
 
+  <div class="col-md-6">
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <h4 class="panel-title">
+          Places you've bookmarked
+        </h4>
+      </div>
+      
+      <div class="panel-body">
+        <div id="location_map" style="height: 360px;"></div>
+      </div>
 
-<div class="row m-b-2">
-  <div class="col-md-12">
-    <div>
-      <div id="location_map" style="height: 480px;"></div>
-    </div>
-  </div>
-</div>
-
-<div class="row">
-  <div class="col-md-12">
     <table class="table table-striped table-hover">
       <tr>
         <th>Name</th>
@@ -73,12 +67,18 @@
           <a href="/delete_venue/<%= venue.id %>" class="btn btn-danger" rel="nofollow">Delete</a>
         </td>
       </tr>
-        <%end%>
+        <% end %>
       <% end %>
     </table>
     <%= paginate @venues, theme: 'twitter-bootstrap-4' %>
   </div>
 </div>
+
+<div class="col-md-3">
+    <a href="/venues/new" class="btn btn-block btn-success">
+      Add a new venue
+    </a>
+  </div>
 
 <script src="//maps.google.com/maps/api/js?v=3.24&key=AIzaSyCOTPWiuvyyo6sKoIBzKA4-1ol-vTOIOlM"></script>
 <script src="//cdn.rawgit.com/mahnunchik/markerclustererplus/master/dist/markerclusterer.min.js"></script>
@@ -90,3 +90,6 @@
     handler.fitMapToBounds();
   });
 </script>
+ 
+ 
+ </div> <!-- this div closes the row. -->


### PR DESCRIPTION
Made UI changes to /dishes to look more like target.

For /dishes and /venues:
-- Updated bootswatch
-- Went from 1 column --> 3 columns on both pages

On /dishes:
- Edited cuisine labels to look more like target
- Made dishes appear alphabetically
- Still need to fix:
-- Margins for rows with heart buttons is a little off
-- Venues in dropdown should be alphabetized
- Misc:
-- Kept pagination (don't know if we need?)

On /venues:
- Still need to fix:
-- Table below map to match target. (Left roughly as-is for now, because I didn't want to mess with any work being done on bookmarks per Trello.)